### PR TITLE
Improve flushing behaviour, remove double buffering

### DIFF
--- a/ats_base_fetch.h
+++ b/ats_base_fetch.h
@@ -56,7 +56,7 @@ private:
   void Lock();
   void Unlock();
   bool DecrefAndDeleteIfUnreferenced();
-  void ForwardData();
+  void ForwardData(const StringPiece& sp, bool last);
   GoogleString buffer_;
   AtsServerContext* server_context_;
   bool done_called_;
@@ -70,8 +70,8 @@ private:
   bool is_resource_fetch_;
   int64_t downstream_length_;
 
-  AbstractMutex* mutex_;
-  //TSMutex mutex_;
+  // We don't own this mutex
+  TSMutex txn_mutex_;
 };
 
 } /* ats_pagespeed */

--- a/ats_speed.cc
+++ b/ats_speed.cc
@@ -551,7 +551,8 @@ ats_transform_one(TransformCtx * ctx, TSIOBufferReader upstream_reader, int amou
     if (upstream_length > amount) {
       upstream_length = amount;
     }
-
+    
+    TSDebug("ats-speed", "transform!");
     // TODO(oschaaf): use at least the message handler from the server conrtext here?
     if (ctx->inflater == NULL) {
       ctx->proxy_fetch->Write(StringPiece((char*)upstream_buffer, upstream_length), ats_process_context->message_handler());
@@ -571,7 +572,7 @@ ats_transform_one(TransformCtx * ctx, TSIOBufferReader upstream_reader, int amou
         }
       }
     }
-
+    //ctx->proxy_fetch->Flush(NULL);
     TSIOBufferReaderConsume(upstream_reader, upstream_length);
     amount -= upstream_length;
   }

--- a/ethread.patch
+++ b/ethread.patch
@@ -1,0 +1,13 @@
+diff --git a/iocore/eventsystem/I_EThread.h b/iocore/eventsystem/I_EThread.h
+index e5f1c56..3d2f9c7 100644
+--- a/iocore/eventsystem/I_EThread.h
++++ b/iocore/eventsystem/I_EThread.h
+@@ -297,7 +297,7 @@ public:
+   virtual ~EThread();
+ 
+   Event *schedule_spawn(Continuation *cont);
+-  Event *schedule(Event *e, bool fast_signal = false);
++  Event *schedule(Event *e, bool fast_signal = true);
+ 
+   /** Block of memory to allocate thread specific data e.g. stat system arrays. */
+   char thread_private[PER_THREAD_DATA];


### PR DESCRIPTION
- Respect flushes, which improves latency with flush_html configured
- Makes us write to the vio output buffer directly
- Fix crasher for aborted requests
