### PR TITLE
Update to build against PSOL 1.7.30.4 beta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL := /bin/bash
 TSXS?=tsxs
 # Specify BUILDTYPE=Debug for a debug build
 BUILDTYPE?=Release
-
 MOD_PAGESPEED_DIR=$(shell pwd)/psol/include/
 PAGESPEED_OUT=$(shell pwd)/psol/lib/$(BUILDTYPE)/linux/x64/
 
@@ -40,15 +39,15 @@ INC =-I$(MOD_PAGESPEED_DIR)\
 PSOL_LIBS = $(PAGESPEED_OUT)pagespeed_automatic.a $(PAGESPEED_OUT)libserf.a $(PAGESPEED_OUT)libaprutil.a $(PAGESPEED_OUT)libapr.a
 
 %.so: psol %.cc
-	g++ $(INC) -shared -o ats_speed.so -g -pipe -Wall -Werror -O3 -fpic $(MOD_PAGESPEED_DIR)/out/$(BUILDTYPE)/obj/gen/data2c_out/instaweb/net/instaweb/apache/install/mod_pagespeed_example/*.cc $(MOD_PAGESPEED_DIR)/net/instaweb/system/*.cc  *.cc -lstdc++ -lstdc++  -lpthread -lrt $(PSOL_LIBS)
+	g++ $(INC) -shared -o ats_speed.so -g -pipe -Wall -Werror -O3 -fpic $(MOD_PAGESPEED_DIR)/out/$(BUILDTYPE)/obj/gen/data2c_out/instaweb/net/instaweb/apache/install/mod_pagespeed_example/*.cc $(MOD_PAGESPEED_DIR)/net/instaweb/system/*.cc  *.cc -lstdc++ -lstdc++  -lpthread $(PSOL_LIBS) -lrt
 
 all: psol gzip/gzip.so ats_speed.so
 
-1.7.30.3.tar.gz:
-	wget https://dl.google.com/dl/page-speed/psol/1.7.30.3.tar.gz
+1.7.30.4.tar.gz:
+	wget https://dl.google.com/dl/page-speed/psol/1.7.30.4.tar.gz
 
-psol/: 1.7.30.3.tar.gz
-	tar -xzvf 1.7.30.3.tar.gz
+psol/: 1.7.30.4.tar.gz
+	tar -xzvf 1.7.30.4.tar.gz
 
 gzip/gzip.so:
 	cd gzip && make

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It also expects this in records.config from ATS to function:
 
 You can view debug output of the plugin using `traffic_server -T ".*speed.*"`
 
-The current state compiles against PSOL 1.7.30.3-beta.
+The current state compiles against PSOL 1.7.30.4-beta.
 Please note the this plugin will generate asserts when build against
 the debug version of mps (option->Merge from a different thread).
 


### PR DESCRIPTION
Update to build against the latest PSOL 1.7 beta release.
From the changelist:

Issues Resolved

Issue 441 Filter "make_google_analytics_async" turns benign call to deprecated method into a functional error.
Issue 781 Images are inlined into CSS styles in IE7 if Firefox renders them first.
Issue 874 Warning messages in log for "ModPagespeed:noscript?".
Issue 880 Combining minified JS files can produce invalid results when deadline exceeded.
Issue 885 Enabling memcached causes "Waiting for property cache" messages and server spinning.
Issue 896 IPRO on reverse proxy can capture gzipped content and serve it to users without content-encoding:gzip.
Issue 898 IPRO does not correctly handle resources which failed to fetch.
